### PR TITLE
Fix duplicate row update: drop and re-append instead of .loc assignment

### DIFF
--- a/code/AutoTest/online_detect.py
+++ b/code/AutoTest/online_detect.py
@@ -84,7 +84,7 @@ for r in results:
             final_res = final_res.append(row)
         else:
             if row['conf'] < final_res.loc[duplicate_mask, 'conf'].values[0]:
-                final_res.loc[duplicate_mask] = row.values
+                final_res = final_res[~duplicate_mask].append(row)
 if len(final_res) > 0:  
     final_res['conf'] = 1 - final_res['conf']
     final_res = final_res.sort_values('conf', ascending = False).rename(columns={"rule": "SDC"})


### PR DESCRIPTION
In-place assignment with .loc failed when row values contained lists, because pandas would unpack them instead of treating them as scalars. Replace with filtering out the duplicate row and appending the new one.